### PR TITLE
metrics: add metrics about stream counts and supported protocols for …

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This plugin can be configured using the usual IPFS configuration.
     "Plugins": {
       "metric-export-plugin": {
         "Config": {
-          "QueryPeerListIntervalSeconds": 10,
+          "PopulatePrometheusInterval": 10,
           "TCPServerConfig": {
             "ListenAddress": "localhost:8181"
           }
@@ -47,14 +47,13 @@ This plugin can be configured using the usual IPFS configuration.
 ...
 ```
 
-### `QueryPeerListIntervalSeconds`
+### `PopulatePrometheusInterval`
 
-The plugin periodically goes through the node's peer store and collects various metrics about the peers.
+The plugin periodically goes through the node's peer store, open connections, and open streams to collect various metrics about them.
 These metrics are then pushed to Prometheus.
 This value controls the interval at which this is done, specified in seconds.
-This operation is not free, and Prometheus itself only scrapes (by default) every 15 seconds.
-
-Setting this value to zero disables the collection and pushing.
+Prometheus itself only scrapes (by default) every 15 seconds, so very small values are probably not useful.
+The default is ten seconds.
 
 ### `TCPServerConfig`
 

--- a/metricplugin/metrics.go
+++ b/metricplugin/metrics.go
@@ -11,11 +11,11 @@ var trafficByGateway = prometheus.NewCounterVec(prometheus.CounterOpts{
 	[]string{"gateway"},
 )
 
-var dhtEnabledPeers = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-	Name: "plugin_metric_export_peers_by_dht_enabled",
-	Help: "Number of currently connected peers, distinguished by whether they speak the DHT protocol or not.",
+var supportedProtocolsAmongConnectedPeers = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "plugin_metric_export_peers_supported_protocols",
+	Help: "Sum of supported protocols over all currently connected peers, as reported by the IPFS node.",
 },
-	[]string{"dht_enabled"},
+	[]string{"protocol"},
 )
 
 var agentVersionCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -24,3 +24,9 @@ var agentVersionCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 },
 	[]string{"agent_version"},
 )
+
+var streamCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "plugin_metric_export_open_streams",
+	Help: "Number of currently open streams, by protocol and direction, as reported by the IPFS node.",
+},
+	[]string{"protocol", "direction"})


### PR DESCRIPTION
…connected peers

This also removes the counting of DHT-enabled peers by the number of `*/kad/*` streams.
This could be unreliable if we ourselves are a DHT server and count incoming streams from DHT clients.
Using the supported protocols should be more robust.

Fixes #12 