### PR TITLE
Add: Cut off value for agentversions reported to prometheus. Fixes #9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This plugin can be configured using the usual IPFS configuration.
       "metric-export-plugin": {
         "Config": {
           "PopulatePrometheusInterval": 10,
+          "AgentVersionCutOff": 20,
           "TCPServerConfig": {
             "ListenAddress": "localhost:8181"
           }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/ipfs/go-bitswap v0.4.0
-	github.com/ipfs/go-cid v0.0.7 // indirect
+	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipfs v0.10.0
 	github.com/ipfs/go-log v1.0.5
 	github.com/libp2p/go-libp2p-core v0.9.0


### PR DESCRIPTION
This PR includes a configurable cut off value for the agentversions that we report to prometheus in order to stop the cluttering.