### PR TITLE
metrics: fix stream counts reporting zero for unused direction+stream…

### DIFF
--- a/metricplugin/metric_export.go
+++ b/metricplugin/metric_export.go
@@ -342,20 +342,26 @@ func (mep *MetricExporterPlugin) populatePrometheus(interval time.Duration) {
 		log.Debugf("populatePrometheus: took %s to calculate stream counts %+v", elapsed, countsByProtocolAndDirection)
 		streamCount.Reset()
 		for protocolID, counts := range countsByProtocolAndDirection {
-			streamCount.With(prometheus.Labels{
-				"protocol":  string(protocolID),
-				"direction": "inbound",
-			}).Set(float64(counts.inbound))
+			if counts.inbound != 0 {
+				streamCount.With(prometheus.Labels{
+					"protocol":  string(protocolID),
+					"direction": "inbound",
+				}).Set(float64(counts.inbound))
+			}
 
-			streamCount.With(prometheus.Labels{
-				"protocol":  string(protocolID),
-				"direction": "outbound",
-			}).Set(float64(counts.outbound))
+			if counts.outbound != 0 {
+				streamCount.With(prometheus.Labels{
+					"protocol":  string(protocolID),
+					"direction": "outbound",
+				}).Set(float64(counts.outbound))
+			}
 
-			streamCount.With(prometheus.Labels{
-				"protocol":  string(protocolID),
-				"direction": "unknown",
-			}).Set(float64(counts.unknown))
+			if counts.unknown != 0 {
+				streamCount.With(prometheus.Labels{
+					"protocol":  string(protocolID),
+					"direction": "unknown",
+				}).Set(float64(counts.unknown))
+			}
 		}
 	}
 }


### PR DESCRIPTION
… combinations

This used to be the situation:
```
plugin_metric_export_open_streams{direction="inbound",protocol=""} 4
plugin_metric_export_open_streams{direction="inbound",protocol="/ipfs/bitswap/1.1.0"} 1
plugin_metric_export_open_streams{direction="inbound",protocol="/ipfs/bitswap/1.2.0"} 35
plugin_metric_export_open_streams{direction="inbound",protocol="/ipfs/id/1.0.0"} 0
plugin_metric_export_open_streams{direction="inbound",protocol="/ipfs/kad/1.0.0"} 141
plugin_metric_export_open_streams{direction="outbound",protocol=""} 33
plugin_metric_export_open_streams{direction="outbound",protocol="/ipfs/bitswap/1.1.0"} 3
plugin_metric_export_open_streams{direction="outbound",protocol="/ipfs/bitswap/1.2.0"} 253
plugin_metric_export_open_streams{direction="outbound",protocol="/ipfs/id/1.0.0"} 13
plugin_metric_export_open_streams{direction="outbound",protocol="/ipfs/kad/1.0.0"} 186
plugin_metric_export_open_streams{direction="unknown",protocol=""} 0
plugin_metric_export_open_streams{direction="unknown",protocol="/ipfs/bitswap/1.1.0"} 0
plugin_metric_export_open_streams{direction="unknown",protocol="/ipfs/bitswap/1.2.0"} 0
plugin_metric_export_open_streams{direction="unknown",protocol="/ipfs/id/1.0.0"} 0
plugin_metric_export_open_streams{direction="unknown",protocol="/ipfs/kad/1.0.0"} 0
```

Should now be cleaned up :)